### PR TITLE
feat(server): add development proxy for Vite

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,17 +30,6 @@ export default defineConfig({
   },
   server: {
     port: 3000,
-    proxy: {
-      '/api': {
-        target: process.env.VITE_API_URL || 'http://localhost:8080',
-        changeOrigin: true,
-      },
-      '/ws': {
-        target: process.env.VITE_API_URL || 'http://localhost:8080',
-        changeOrigin: true,
-        ws: true,
-      },
-    },
   },
   define: {
     'process.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || 'http://localhost:8080'),

--- a/internal/server/dev_proxy.go
+++ b/internal/server/dev_proxy.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+// DevProxy handles proxying requests to the Vite development server
+type DevProxy struct {
+	proxy  *httputil.ReverseProxy
+	logger *zap.Logger
+	target string
+}
+
+// NewDevProxy creates a new development proxy instance
+func NewDevProxy(viteURL string, logger *zap.Logger) (*DevProxy, error) {
+	target, err := url.Parse(viteURL)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+
+	// Customize the director to handle WebSocket upgrades and other headers
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.Header.Set("X-Forwarded-Host", req.Header.Get("Host"))
+		req.Header.Set("X-Origin-Host", req.Header.Get("Host"))
+		req.Header.Set("X-Forwarded-Proto", "http")
+	}
+
+	devProxy := &DevProxy{
+		proxy:  proxy,
+		logger: logger,
+		target: viteURL,
+	}
+
+	// Handle errors
+	proxy.ErrorHandler = devProxy.errorHandler
+
+	logger.Info("Development proxy configured", zap.String("target", viteURL))
+
+	return devProxy, nil
+}
+
+// ServeHTTP handles the proxy request
+func (dp *DevProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	dp.logger.Debug("Proxying request to Vite dev server",
+		zap.String("path", r.URL.Path),
+		zap.String("method", r.Method),
+	)
+
+	dp.proxy.ServeHTTP(w, r)
+}
+
+// ShouldProxy determines if a request should be proxied to the dev server
+func (dp *DevProxy) ShouldProxy(path string) bool {
+	// Skip API and WebSocket routes - they should be handled by their respective handlers
+	return !strings.HasPrefix(path, "/api/") && !strings.HasPrefix(path, "/ws")
+}
+
+// errorHandler handles proxy errors
+func (dp *DevProxy) errorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	dp.logger.Error("Vite proxy error",
+		zap.Error(err),
+		zap.String("url", r.URL.String()),
+		zap.String("target", dp.target),
+	)
+	http.Error(w, "Vite dev server not available", http.StatusBadGateway)
+}


### PR DESCRIPTION
- Introduces a new `DevProxy` struct to handle proxying requests to the Vite development server during local development
- The `Server` struct now has a `devProxy` field that is set up if `serve_static` is false, allowing the server to proxy non-API and non-WebSocket requests to the Vite dev server
- The `DevProxy` struct customizes the reverse proxy to handle WebSocket upgrades and other headers, and includes an error handler to log and respond to proxy errors
- The `vite.config.ts` file has been updated to remove the proxy configuration, as this functionality is now handled by the server-side proxy

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #17 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #16 
<!-- GitButler Footer Boundary Bottom -->

